### PR TITLE
Better compression for share links

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
-2.5.3:
+2.5.4:
+  - new - shared links are now shorter, as words starting with the same letter are compressed more efficiently
+2.5.3 15.01.2024:
   - new - fast deploy system
   - new - share button desing
 2.5.2 14.01.2024:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "literalnie"
   ],
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/utils/urlHash.ts
+++ b/src/utils/urlHash.ts
@@ -21,7 +21,7 @@ interface ChunkInfo {
 
 export const getChunkKeyPartWithPreviousUsedAsShadow = (key: string, previousKey: string | undefined = '') => {
     if (key.length !== 3) {
-        throw `Key must be 3 letters length. key: ${key}, previousKey: ${previousKey}`;
+        throw `Key must be 3 letters in length. key: ${key}, previousKey: ${previousKey}`;
     }
 
     if (key === previousKey) {
@@ -46,7 +46,7 @@ export const getFullChunkKeyWithPreviousUsedAsShadow = (key: string | undefined 
 
     if (previousKey.length !== 3) {
         // If the first one is missing then this has to be filled
-        throw 'Shadow key must be 3 letters length';
+        throw 'Shadow key must be 3 letters in length';
     }
 
     return `${previousKey.slice(0, 3 - key.length)}${key}`;


### PR DESCRIPTION
### Before ?r= 71 ch.
https://deykun.github.io/diffle-lang/?r=ESKy0ycldmL2YWMuATYy0ycvdmLyEWMt42bn5SY4EWLhJ3ZuATMucTMuAjLwEjL0NXZnhSI

`!(gest.10.0.17.10.gra-a8a.gon-1a2.gos-2a0.1f6.ges-2)!`

### After ?r= 66 ch. (-7%)
https://deykun.github.io/diffle-lang/?r=QIpITLzVmL2YWMuATYy0ycuITYx0ibv5SY4EWLhJ3ZuATMucTMuAjLwEjL0NXZnhSI
`!(gest.10.0.17.10.gra-a8a.on-1a2.s-2a0.1f6.es-2)!`

Both links will work.

![obraz](https://github.com/Deykun/diffle-lang/assets/21176665/52741070-153b-4d5f-9021-a6ca70a735e1)

### How it works?
After discovering the first letter users use it as the initial letter and it's our initial letter in keys too. If they consistently start with the same letter that PR leverages this approach, so when we obtain `kod,as,t,c` we use the first one as a base and derive `kod,kas,kat,kac` incrementally.

