### PR TITLE
🪟 The broken background blur on the keyboard was fixed in Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@
 
 ---
 
-#### Version 3.35.1
-- **Bug**: The Italian title doesn't indicate that the game is in Polish
+#### Version 3.35.2
+- **Fix**: The broken background blur on the keyboard was fixed in Chrome
+
+#### Version 3.35.1 (19.01.2025)
+- **Fix**: The Italian title doesn't indicate that the game is in Polish
 
 #### Version 3.35 (19.01.2025)
 - **New**: Adding support for the Home and End keys

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "slowoku"
   ],
   "private": true,
-  "version": "3.35.1",
+  "version": "3.35.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3001",

--- a/src/App.scss
+++ b/src/App.scss
@@ -123,8 +123,19 @@ body {
 
 main {
     & > div {
-        opacity: 0;
-        animation: fadeIn 0.3s ease-out forwards;
+        &::after {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: var(--background);
+            z-index: 1;
+            pointer-events: none;
+            opacity: 1;
+            animation: fadeOut 0.4s ease-out forwards;
+        }
     }
 }
 


### PR DESCRIPTION
![obraz](https://github.com/user-attachments/assets/cdb46f65-7ffd-4577-a4c6-64a1b1419523)

Pages in the app have opacity animations, and Chrome has a bug where two blurred elements, or one blurred element with an opacity transition animation, can break it.

https://stackoverflow.com/questions/60997948/backdrop-filter-not-working-for-nested-elements-in-chrome#comment124751483_64754474